### PR TITLE
fix: [CO-1838] update patch version of react-device-detect to 2.2.3 and peer dependency ua-parser-js to 1.0.40

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
 				"polished": "^4.2.2",
 				"prop-types": "^15.8.1",
 				"react": "17.0.2",
-				"react-device-detect": "2.2.2",
+				"react-device-detect": "2.2.3",
 				"react-dom": "^17.0.2",
 				"react-i18next": "^11.13.0",
 				"react-router-dom": "^5.3.0",
@@ -18634,11 +18634,11 @@
 			}
 		},
 		"node_modules/react-device-detect": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/react-device-detect/-/react-device-detect-2.2.2.tgz",
-			"integrity": "sha512-zSN1gIAztUekp5qUT/ybHwQ9fmOqVT1psxpSlTn1pe0CO+fnJHKRLOWWac5nKxOxvOpD/w84hk1I+EydrJp7SA==",
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/react-device-detect/-/react-device-detect-2.2.3.tgz",
+			"integrity": "sha512-buYY3qrCnQVlIFHrC5UcUoAj7iANs/+srdkwsnNjI7anr3Tt7UY6MqNxtMLlr0tMBied0O49UZVK8XKs3ZIiPw==",
 			"dependencies": {
-				"ua-parser-js": "^1.0.2"
+				"ua-parser-js": "^1.0.33"
 			},
 			"peerDependencies": {
 				"react": ">= 0.14.0",
@@ -21304,9 +21304,9 @@
 			}
 		},
 		"node_modules/ua-parser-js": {
-			"version": "1.0.32",
-			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.32.tgz",
-			"integrity": "sha512-dXVsz3M4j+5tTiovFVyVqssXBu5HM47//YSOeZ9fQkdDKkfzv2v3PP1jmH6FUyPW+yCSn7aBVK1fGGKNhowdDA==",
+			"version": "1.0.40",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.40.tgz",
+			"integrity": "sha512-z6PJ8Lml+v3ichVojCiB8toQJBuwR42ySM4ezjXIqXK3M0HczmKQ3LF4rhU55PfD99KEEXQG6yb7iOMyvYuHew==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -21315,8 +21315,15 @@
 				{
 					"type": "paypal",
 					"url": "https://paypal.me/faisalman"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/faisalman"
 				}
 			],
+			"bin": {
+				"ua-parser-js": "script/cli.js"
+			},
 			"engines": {
 				"node": "*"
 			}
@@ -36270,11 +36277,11 @@
 			}
 		},
 		"react-device-detect": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/react-device-detect/-/react-device-detect-2.2.2.tgz",
-			"integrity": "sha512-zSN1gIAztUekp5qUT/ybHwQ9fmOqVT1psxpSlTn1pe0CO+fnJHKRLOWWac5nKxOxvOpD/w84hk1I+EydrJp7SA==",
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/react-device-detect/-/react-device-detect-2.2.3.tgz",
+			"integrity": "sha512-buYY3qrCnQVlIFHrC5UcUoAj7iANs/+srdkwsnNjI7anr3Tt7UY6MqNxtMLlr0tMBied0O49UZVK8XKs3ZIiPw==",
 			"requires": {
-				"ua-parser-js": "^1.0.2"
+				"ua-parser-js": "^1.0.33"
 			}
 		},
 		"react-dom": {
@@ -38327,9 +38334,9 @@
 			"dev": true
 		},
 		"ua-parser-js": {
-			"version": "1.0.32",
-			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.32.tgz",
-			"integrity": "sha512-dXVsz3M4j+5tTiovFVyVqssXBu5HM47//YSOeZ9fQkdDKkfzv2v3PP1jmH6FUyPW+yCSn7aBVK1fGGKNhowdDA=="
+			"version": "1.0.40",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.40.tgz",
+			"integrity": "sha512-z6PJ8Lml+v3ichVojCiB8toQJBuwR42ySM4ezjXIqXK3M0HczmKQ3LF4rhU55PfD99KEEXQG6yb7iOMyvYuHew=="
 		},
 		"uglify-js": {
 			"version": "3.17.4",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
 		"polished": "^4.2.2",
 		"prop-types": "^15.8.1",
 		"react": "17.0.2",
-		"react-device-detect": "2.2.2",
+		"react-device-detect": "2.2.3",
 		"react-dom": "^17.0.2",
 		"react-i18next": "^11.13.0",
 		"react-router-dom": "^5.3.0",


### PR DESCRIPTION
The dependency react-device-detect 2.2.2 depends on ua-parser-js ^1.0.2.
ua-parser-js contains vulnerabilities until 1.0.33.
By bumping react-device-detect to 2.2.3, which requires a minimum version of ^1.0.33 it is ensured a non-vulnerable ua-parser-js will be used. The deployed version will actually be ua-parser-js 1.0.40 (see package.lock.json)