### PR TITLE
fix: [CO-2901] exclude mocks and msw from build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,11 +3,11 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 library(
-    identifier: 'zapp-jenkins-lib@1.0.3',
+    identifier: 'jenkins-lib-ui@1.0.4',
     retriever: modernSCM([
         $class: 'GitSCMSource',
-        remote: 'git@github.com:zextras/jenkins-zapp-lib.git',
-        credentialsId: 'jenkins-integration-with-github-account'
+        credentialsId: 'jenkins-integration-with-github-account',
+        remote: 'git@github.com:zextras/jenkins-lib-ui.git',
     ])
 )
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -12,10 +12,4 @@ import './i18n/i18n.config';
 import './index.css';
 import { App } from './app';
 
-if (process.env.NODE_ENV === 'development') {
-	// eslint-disable-next-line @typescript-eslint/no-var-requires,global-require
-	const { worker } = require('./mocks/browser');
-	worker.start();
-}
-
 render(<App />, document.getElementById('app'));

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -87,6 +87,9 @@ const config = (
 		},
 		plugins: [
 			new CleanWebpackPlugin(),
+			new webpack.DefinePlugin({
+				'process.env.NODE_ENV': JSON.stringify(args.mode || 'production')
+			}),
 			new webpack.IgnorePlugin({
 				resourceRegExp: /^\.?\.?\/mocks\// // ignore any import that starts with ./mocks/ or ../mocks/
 			}),

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -29,15 +29,6 @@ const config = (
 			path: `${__dirname}/dist`
 		},
 		target: 'web',
-		devServer: {
-			proxy: {
-				'/zx': {
-					target: 'https://infra-848931f5.testarea.zextras.com',
-					secure: false
-				}
-			},
-			webSocketServer: false
-		},
 		resolve: {
 			extensions: ['*', '.js', '.jsx', '.ts', '.tsx'],
 			alias: {
@@ -48,7 +39,7 @@ const config = (
 			rules: [
 				{
 					test: /\.[jt]sx?$/,
-					exclude: /node_modules/,
+					exclude: [/node_modules/, path.resolve(process.cwd(), 'src/mocks')],
 					loader: 'babel-loader'
 				},
 				{
@@ -96,6 +87,9 @@ const config = (
 		},
 		plugins: [
 			new CleanWebpackPlugin(),
+			new webpack.IgnorePlugin({
+				resourceRegExp: /^\.?\.?\/mocks\// // ignore any import that starts with ./mocks/ or ../mocks/
+			}),
 			new CopyPlugin({
 				patterns: [
 					{ from: 'CHANGELOG.md', to: '.', noErrorOnMissing: true },
@@ -110,8 +104,7 @@ const config = (
 								.replaceAll('{{version}}', pkg.version)
 								.replaceAll('{{pkgRel}}', `${pkgRel}`);
 						}
-					},
-					{ from: 'src/mockServiceWorker.js', to: 'mockServiceWorker.js' }
+					}
 				]
 			}),
 			new HtmlWebpackPlugin({


### PR DESCRIPTION
Code was bundling mocks and msw, causing http calls to be intercepted by msw.
So the UI was not actually calling the backend, but was receiveing mocks from msw, resulting in a bug where wrong values/images,etc. appeared in the login UI