### PR TITLE
build: migrate to buildah (FQDN images + jenkins-lib-common@2.10.0)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM alpine:3.22.2 AS builder
+FROM --platform=$BUILDPLATFORM docker.io/library/alpine:3.22.2 AS builder
 
 ENV WEB_PATH="/opt/zextras/web/login"
 
@@ -9,7 +9,7 @@ RUN mkdir -p "${WEB_PATH}"
 COPY dist ${WEB_PATH}/
 
 # Final stage - built for all target platforms
-FROM alpine:3.22.2
+FROM docker.io/library/alpine:3.22.2
 
 # Just copy the prepared files (no execution needed)
 COPY --from=builder /opt/zextras /opt/zextras

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 library(
-    identifier: 'jenkins-lib-common@v2.7.0',
+    identifier: 'jenkins-lib-common@v2.10.0',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         remote: 'git@github.com:zextras/jenkins-lib-common.git',


### PR DESCRIPTION
## Buildah migration

Replacing `docker buildx` with **buildah**, which requires fully-qualified image references.

### Changes
- **Dockerfiles:** fully-qualify base images (e.g. `alpine:3` -> `docker.io/library/alpine:3`). Multi-stage aliases and already-qualified refs untouched.
- **Jenkinsfile:** bump `jenkins-lib-common` to `@2.10.0`.

> Draft - part of org-wide buildah migration.